### PR TITLE
formulated a second Text Referencing API inspired on IIIF

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "textsurf"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["Maarten van Gompel <proycon@anaproy.nl>"]
 description = "Webservice for efficiently serving multiple plain text documents or excerpts thereof (by unicode character offset), without everything into memory."

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ These are extra endpoints that are available but not part of the Text Referencin
 * `GET /api-doc/openapi.json`   - Machine parseable OpenAPI specification.
 
 
-## Text Referencing API: Formal Specification
+## Text Referencing API 1: Formal Specification
 
 Textsurf implements a minimal **Text Referencing API** that is directly derived from 
 [RFC5147](https://www.rfc-editor.org/rfc/rfc5147.txt). RFC5147 specifies URI
@@ -96,6 +96,48 @@ as defined in section 3 of [RFC5147](https://www.rfc-editor.org/rfc/rfc5147.txt)
     * `checksum` - A SHA-256 checksum of the entire textfile.
     * `mtime` - The modification time of the file in number of seconds since the unix epoch (1970-01-01 00:00).
 6. Any of the endpoints *MAY* be restricted to authenticated or authorized users only., This specification does not define a specific mechanism for that as it is beyond it's scope.
+
+## Text Referencing API 2: Formal Specification
+
+In addition to the above API, Textsurf implements a **second Text
+Referencing API**. Though there are two separate interfaces, the functionality they
+expose is identical and it is a matter of preference which one you want to use.
+The secondary API is available under the `/api2/` endpoint. It was designed not
+to use query parameters, interoperate closer with linked open data, and is
+modelled after the [IIIF Image API](https://iiif.io/api/image/3.0/). 
+
+The capitalized key words "MUST", "MUST NOT", "REQUIRED", "SHALL",
+"SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and
+"OPTIONAL" in this section are to be interpreted as described in 
+[RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+1. A request for a text file or text segment therein *MUST* be a `HTTP GET` request conforming to the following URI template: `{scheme}://{server}{/prefix}/{identifier}{/region}`
+    * `scheme` - Indicates the use of the HTTP or HTTPS protocol in calling the service.
+    * `server` - The host server on which the service resides. The parameters *MAY* also contain a port number.
+    * `prefix` - The path on the host server to the service. This prefix is *OPTIONAL* from the point of view of this specification, but it is *REQUIRED* to end in `/api2` for the TextSurf implementation. A prefix may be useful when the host server supports multiple services. The prefix may contain multiple path segments, delimited by slashes, but all other special characters must be encoded.
+    * `identifier` - The identifier of the requested text. This must be a filename and *MAY* contain path information, but special characters including slashes for directory hierarchy *MUST* be URI encoded. The text file *MUST* be retrievable by its full extension. It *MAY* also be retrievable by having an implied default extension. Example: `https://example.org/api2/test` for `https://example.org/api2/test.txt`
+    * `region` - This parameter is *OPTIONAL* and used when requesting a subpart of the text. Syntax is as follows:
+        * `full` - Returns the full text, same as just omitted the region parameter entirely
+        * `{begin},{end}` - Returns the text from character begin to end. 
+            * Characters correspond to unicode points and *MUST* be 0-indexed, the end *MUST* be non-inclusive.  Example: `0,1` returns the first character of a text. 
+            * Negative offsets *MUST* be supported and are interpreted relative to the end of the text. 
+            * If the end value is omitted, the offset is interpreted to be the end of the text. Example: `-1,` returns the last character of a text.
+        * `char:{begin},{end}` - Same as above
+        * `line:{begin},{end}` - Returns lines, lines *MUST* be 0-indexed and the end *MUST* be non-inclusive.
+2. A text file *MUST* be submittable via a `HTTP POST` call on the same URI as in point 1, but without the region part, and provided the server is not in a read-only state.
+    1. If the text file contains path components, the necessary directories *SHOULD* be automatically created.
+    2. The file is transferred in the request body.
+3. A text file *MUST* be removable via a `HTTP DELETE` call on its URI, provided the server is not in a read-only state.
+4. A request for text information *MUST* conform to the following URI template: `{scheme}://{server}{/prefix}/{identifier}/info.json`. This *SHOULD* return a *JSON* response with the following keys:
+    * `@context` - `https://w3id.org/textsurf/api2.jsonld`
+    * `id` - URI of the text file
+    * `type` - `TextService2`
+    * `protocol` - `https://w3id.org/textsurf/api2`
+    * `bytes` - The filesize of the file in bytes
+    * `chars` - The length of the text file in unicode points.
+    * `checksum` - A SHA-256 checksum of the entire textfile.
+    * `mtime` - The modification time of the file in number of seconds since the unix epoch (1970-01-01 00:00).
+5. Any of the endpoints *MAY* be restricted to authenticated or authorized users only., This specification does not define a specific mechanism for that as it is beyond it's scope.
 
 ## Installation
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -24,6 +24,12 @@ pub enum ApiResponse {
         mtime: u64,
         checksum: String,
     },
+    StatLD {
+        chars: u64,
+        bytes: u64,
+        mtime: u64,
+        checksum: String,
+    },
     JsonList(Vec<Value>),
 }
 
@@ -48,6 +54,22 @@ impl IntoResponse for ApiResponse {
                 checksum,
             } => {
                 let mut map: BTreeMap<&'static str, Value> = BTreeMap::new();
+                map.insert("chars", chars.into());
+                map.insert("bytes", bytes.into());
+                map.insert("mtime", mtime.into());
+                map.insert("checksum", checksum.into());
+                (StatusCode::OK, [cors, server], Json(map)).into_response()
+            }
+            Self::StatLD {
+                chars,
+                bytes,
+                mtime,
+                checksum,
+            } => {
+                let mut map: BTreeMap<&'static str, Value> = BTreeMap::new();
+                map.insert("@context", "https://w3id.org/textsurf/api2.jsonld".into());
+                map.insert("type", "TextService2".into());
+                map.insert("protocol", "https://w3id.org/textsurf/api2".into());
                 map.insert("chars", chars.into());
                 map.insert("bytes", bytes.into());
                 map.insert("mtime", mtime.into());

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,7 @@ async fn main() {
         .route("/api2/{text_id}", get(get_api2_short))
         .route("/api2/{text_id}/{region}", get(get_api2_with_region)) //also used for info.json for stat
         .route("/api2/{text_id}", post(create_text_api2))
-        .route("/api2/{text_id}", post(delete_text_api2))
+        .route("/api2/{text_id}", delete(delete_text_api2))
         .route("/{*text_id}", get(get_text))
         .route("/{*text_id}", post(create_text))
         .route("/{*text_id}", delete(delete_text))

--- a/test/test.http
+++ b/test/test.http
@@ -11,6 +11,9 @@ GET http://127.0.0.1:8080/julesverne?char=1615,1826
 ### Retrieve a particular text slice (line-schema syntax like in RFC5147)
 GET http://127.0.0.1:8080/julesverne?line=500,510
 
+### Retrieve a particular text slice (API2)
+GET http://127.0.0.1:8080/api2/julesverne/1615,1826
+
 ### Receive the last 200 characters
 GET http://127.0.0.1:8080/julesverne?begin=-200
 
@@ -22,6 +25,9 @@ GET http://127.0.0.1:8080/doesnotexist
 
 ### Get metadata (size, last modification time)
 GET http://127.0.0.1:8080/stat/julesverne
+
+### Get metadata (API2)
+GET http://127.0.0.1:8080/api2/julesverne/info.json
 
 ### Add a new text (note that this adds a directory test to place it in)
 POST http://127.0.0.1:8080/test/hello
@@ -58,3 +64,4 @@ GET http://127.0.0.1:8080/test/hello?char=2,4&md5=c086b3008aca0efa8f2ded065d6afb
 
 ### Delete a text 
 DELETE http://127.0.0.1:8080/test/hello
+


### PR DESCRIPTION
This is a proposed secondary API for TextSurf that is closely modelled after the IIIF Image API, as this was a wish from @hennie to find better integration with the IIIF community.

If approved, the already existing simple ( '/s/`) entrypoint will replaced by this API in TextSurf.