### PR TITLE
chore: Implement multi-stage build in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,20 @@
+# Build stage
+FROM alpine:latest AS builder
+
+RUN apk update && apk add cargo git
+
+COPY . /usr/src/
+
+WORKDIR /usr/src/
+
+RUN cargo install --root /usr/ --path .
+
+# Runtime stage
 FROM alpine:latest
 
 ARG UID=1000
 
-RUN apk update && apk add cargo runit sudo git && adduser -u $UID -D user && mkdir -p /usr/src /etc/service/textsurf
-
-COPY . /usr/src/
+RUN apk update && apk add runit sudo libgcc && adduser -u $UID -D user && mkdir -p /etc/service/textsurf
 
 # Set to one to make the service writable instead of read-only. Note that the service itself does not offer any authentication!!!
 ENV WRITABLE=0
@@ -15,12 +25,16 @@ ENV UNLOADTIME=600
 # Set to 1 for debug output
 ENV DEBUG=0
 
-WORKDIR /usr/src/
+RUN mkdir -p /usr/src
 
-RUN cargo install --root /usr/ --path . &&\
-    mv etc/textsurf.run.sh /etc/service/textsurf/run
+# Copy the compiled binary from builder stage
+COPY --from=builder /usr/bin/textsurf /usr/bin/textsurf
+
+# Copy the run script
+COPY etc/textsurf.run.sh /etc/service/textsurf/run
 
 EXPOSE 8080
 VOLUME /data
 
 ENTRYPOINT ["runsvdir","-P","/etc/service"]
+


### PR DESCRIPTION
Refactor Dockerfile to include a multi-stage build for better efficiency and reduce final image size. 

The idea is to have a build stage to build the rust software which needs the rust toolchain and a runner which simply copies the generated binary from the build stage and only runs the binary and only needs minimal dependencies. The use of the container should be exactly the same. This is especially relevant when publishing the software on a container repository. 
The image size goes from from about 1GB to 30MB.
